### PR TITLE
Add setCipher method.

### DIFF
--- a/BigCommerce/Api.php
+++ b/BigCommerce/Api.php
@@ -74,6 +74,14 @@ class BigCommerce_Api
 	}
 
 	/**
+	 * Set which cipher to use during SSL requests.
+	 */
+	public static function setCipher($cipher='RC4-SHA')
+	{
+		self::connection()->setCipher($cipher);
+	}
+
+	/**
 	 * Connect to the internet through a proxy server.
 	 *
 	 * @param string $host host server

--- a/BigCommerce/Api/Connection.php
+++ b/BigCommerce/Api/Connection.php
@@ -157,6 +157,15 @@ class BigCommerce_Api_Connection
 	}
 
 	/**
+	 * Set which cipher to use during SSL requests.
+	 * @param string $cipher the name of the cipher
+	 */
+	public function setCipher($cipher='RC4-SHA')
+	{
+		curl_setopt($this->curl, CURLOPT_SSL_CIPHER_LIST, $cipher);
+	}
+
+	/**
 	 * Add a custom header to the request.
 	 */
 	public function addHeader($header, $value)

--- a/README.md
+++ b/README.md
@@ -273,6 +273,18 @@ The exceptions thrown are subclasses of BigCommerce_Api_Error, representing
 client errors and server errors. The API documentation for response codes
 contains a list of all the possible error conditions the client may encounter.
 
+Specifying the SSL cipher
+-------------------------
+
+The API requires that all client SSL connections use the rsa_rc4_128_sha cipher.
+This should not be an issue as curl will use this by default. In those
+situations where this is not the case the you will need to use the setCipher
+method to force curl to use the correct cipher.
+
+```
+BigCommerce_Api::setCipher('RC4-SHA');
+```
+
 Verifying SSL certificates
 --------------------------
 


### PR DESCRIPTION
Some systems may not use the rsa_rc4_128_sha cipher by default when using curl to send a SSL request. I've added a setCipher method that works in the same vein as verifyPeer. It should allow client code to force curl to use the correct cipher. 
