### PR TITLE
RC4-SHA cipher is now used by default as its the only cipher that Bigcommerce supports

### DIFF
--- a/BigCommerce/Api/Connection.php
+++ b/BigCommerce/Api/Connection.php
@@ -82,6 +82,9 @@ class BigCommerce_Api_Connection
 		curl_setopt($this->curl, CURLOPT_HEADERFUNCTION, array($this, 'parseHeader'));
 		curl_setopt($this->curl, CURLOPT_WRITEFUNCTION, array($this, 'parseBody'));
 
+		// Bigcommerce only supports RC4-SHA
+		$this->setCipher('RC4-SHA');
+
 		if (!ini_get("open_basedir")) {
 			curl_setopt($this->curl, CURLOPT_FOLLOWLOCATION, true);
 		} else {

--- a/README.md
+++ b/README.md
@@ -276,10 +276,10 @@ contains a list of all the possible error conditions the client may encounter.
 Specifying the SSL cipher
 -------------------------
 
-The API requires that all client SSL connections use the rsa_rc4_128_sha cipher.
-This should not be an issue as curl will use this by default. In those
-situations where this is not the case the you will need to use the setCipher
-method to force curl to use the correct cipher.
+The API requires that all client SSL connections use the RC4-SHA (rsa_rc4_128_sha) cipher.
+The client will set this cipher to be used by default.
+
+The setCipher method can be used to override this setting if required.
 
 ```
 BigCommerce_Api::setCipher('RC4-SHA');


### PR DESCRIPTION
attn @maetl
