### PR TITLE
Reset default request method after DELETE

### DIFF
--- a/src/Bigcommerce/Api/Connection.php
+++ b/src/Bigcommerce/Api/Connection.php
@@ -376,6 +376,9 @@ class Connection
 		curl_setopt($this->curl, CURLOPT_CUSTOMREQUEST, 'DELETE');
 		curl_setopt($this->curl, CURLOPT_URL, $uri);
 		curl_exec($this->curl);
+		
+		// reset back to the default request method
+		curl_setopt($this->curl, CURLOPT_CUSTOMREQUEST, 'GET');
 
 		return $this->handleResponse();
 	}


### PR DESCRIPTION
This is a workaround for cURL's crappy API design choices. After a DELETE request is sent , reset the default request method to GET so that it doesn’t break when doing a sequence of requests after the DELETE.
