### PR TITLE
Force a new connection to be made if the client is reconfigured

### DIFF
--- a/src/Bigcommerce/Api/Client.php
+++ b/src/Bigcommerce/Api/Client.php
@@ -50,6 +50,7 @@ class Client
 		self::$api_key 	 = $settings['api_key'];
 		self::$store_url = rtrim($settings['store_url'], '/');
 		self::$api_path  = self::$store_url . self::$path_prefix;
+		self::$connection = false;
 	}
 
 	/**


### PR DESCRIPTION
If the library is used for multiple shopping carts, it will fail due to it trying to use the same credentials for all carts...even if new credentials are provided.  This commit forces a new connection to be made if configure is called.
