### PR TITLE
Incorrectly names classes

### DIFF
--- a/src/Bigcommerce/Api/Resources/ProductConfigurableField.php
+++ b/src/Bigcommerce/Api/Resources/ProductConfigurableField.php
@@ -8,7 +8,7 @@ use Bigcommerce\Api\Client;
 /**
  * A configurable field on a product.
  */
-class ConfigurableField extends Resource
+class ProductConfigurableField extends Resource
 {
 
 }

--- a/src/Bigcommerce/Api/Resources/ProductCustomField.php
+++ b/src/Bigcommerce/Api/Resources/ProductCustomField.php
@@ -8,7 +8,7 @@ use Bigcommerce\Api\Client;
 /**
  * A custom field on a product.
  */
-class CustomField extends Resource
+class ProductCustomField extends Resource
 {
 
 }

--- a/src/Bigcommerce/Api/Resources/ProductVideo.php
+++ b/src/Bigcommerce/Api/Resources/ProductVideo.php
@@ -8,7 +8,7 @@ use Bigcommerce\Api\Client;
 /**
  * A product video.
  */
-class Video extends Resource
+class ProductVideo extends Resource
 {
 
 }


### PR DESCRIPTION
The names of three of the resource classes are incorrect.
The product resource class contains resources for ProductVideo, ProductCustomField, and ProductConfigurableField.

In the files for these classes they are named Video, CustomField, and ConfigurableField.
