### PR TITLE
Fatal error: Class 'Bigcommerce\Api\Exception' not found

### DIFF
--- a/src/Bigcommerce/Api/Client.php
+++ b/src/Bigcommerce/Api/Client.php
@@ -2,6 +2,8 @@
 
 namespace Bigcommerce\Api;
 
+use \Exception as Exception;
+
 /**
  * Bigcommerce API Client.
  */


### PR DESCRIPTION
Fixes "Fatal error: Class 'Bigcommerce\Api\Exception' not found" when an Exception is thrown in configure
