### PR TITLE
Set a connection timeout

### DIFF
--- a/src/Bigcommerce/Api/Connection.php
+++ b/src/Bigcommerce/Api/Connection.php
@@ -92,6 +92,8 @@ class Connection
 		} else {
 			$this->followLocation = true;
 		}
+		
+		$this->setTimeout(60);
 	}
 
 	/**


### PR DESCRIPTION
I've found that a CURL connection can hang indefinitely without a timeout set.

The curl library doesn't have a default timeout and instead relies on socket timeouts built into the operating system.  Curl doesn't use the "default_socket_timeout" php ini either.