### PR TITLE
Close tmpfile() in Connection::put

### DIFF
--- a/bigcommerce.php
+++ b/bigcommerce.php
@@ -180,6 +180,7 @@ class Connection
         curl_setopt($this->curl, CURLOPT_URL, $url);
         curl_setopt($this->curl, CURLOPT_PUT, true);
         curl_exec($this->curl);
+        fclose($handle);
         return $this->handleResponse();
     }
     public function delete($url)


### PR DESCRIPTION
Prevents crashes for scripts issuing high numbers (~990) of PUT requests
