### PR TITLE
Small fixes

### DIFF
--- a/src/Bigcommerce/Api/Resources/Shipment.php
+++ b/src/Bigcommerce/Api/Resources/Shipment.php
@@ -12,7 +12,8 @@ class Shipment extends Resource
         'order_id',
         'date_created',
         'customer_id',
-        'shipping_method',
+        'billing_address',
+        'shipping_address'
     );
 
     protected $ignoreOnUpdate = array(
@@ -20,8 +21,9 @@ class Shipment extends Resource
         'order_id',
         'date_created',
         'customer_id',
-        'shipping_method',
         'items',
+        'billing_address',
+        'shipping_address'
     );
 
     public function create()

--- a/src/Bigcommerce/Api/Resources/Sku.php
+++ b/src/Bigcommerce/Api/Resources/Sku.php
@@ -19,17 +19,6 @@ class Sku extends Resource
         'product_id',
     );
 
-    public function options()
-    {
-        $options = Client::getCollection($this->fields->options->resource, 'SkuOption');
-
-        foreach ($options as $option) {
-            $option->product_id = $this->product_id;
-        }
-
-        return $options;
-    }
-
     public function create()
     {
         return Client::createResource('/products/' . $this->product_id . '/skus', $this->getCreateFields());


### PR DESCRIPTION
Made a couple of small fixes to the PHP API Library:

1)  Sku class had an options() method that tried to pull a list of options from a separate resource - this is not needed as a sku object has data to access in the 'options' parameter.  Leaving this method creates a conflict trying to access the array under the 'options' property.
Here is an example:

{
    "id": 1,
    "product_id": 5,
    "sku": "MB-1",
    "cost_price": "0.0000",
    "upc": "",
    "inventory_level": 0,
    "inventory_warning_level": 0,
    "bin_picking_number": "",
    "options": [
      {
        "product_option_id": 15,
        "option_value_id": 17
      },
      {
        "product_option_id": 16,
        "option_value_id": 28
      }
    ]
  }

2)  The Shipment class had incorrect ignore values.  Namely it was set to ignore 'shipping_method' even though that is an updatable field.

Read-only fields can be seen here:
https://developer.bigcommerce.com/api/stores/v2/orders/shipments