### PR TITLE
API-94 - adding else case to switch back to JSON mode if useXml is false

### DIFF
--- a/src/Bigcommerce/Api/Connection.php
+++ b/src/Bigcommerce/Api/Connection.php
@@ -115,6 +115,9 @@ class Connection
         if ($option) {
             $this->contentType = self::MEDIA_TYPE_XML;
             $this->rawResponse = true;
+        } else {
+            $this->contentType = self::MEDIA_TYPE_JSON;
+            $this->rawResponse = false;
         }
     }
 


### PR DESCRIPTION
## What
Else case to switch content type and "use raw" back to JSON-based settings.

## Why
Inability to turn this off was hindering functional testing.