### PR TITLE
Add filters to Order->products

### DIFF
--- a/src/Bigcommerce/Api/Client.php
+++ b/src/Bigcommerce/Api/Client.php
@@ -1043,6 +1043,17 @@ class Client
     {
         return self::getCollection('/customers/' . $id . '/addresses', 'Address');
     }
+    
+    /**
+     * Get the customer group by the given id
+     * 
+     * @param int $id group id
+     * @return Resources\CustomerGroup
+     */
+    public static function getGroup($id)
+	{
+		return self::getResource('/customer_groups/' . $id, 'CustomerGroup');
+	}
 
     /**
      * Returns the collection of option sets.

--- a/src/Bigcommerce/Api/Resources/CustomerGroup.php
+++ b/src/Bigcommerce/Api/Resources/CustomerGroup.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Bigcommerce\Api\Resources;
+
+use Bigcommerce\Api\Resource;
+use Bigcommerce\Api\Client;
+
+class CustomerGroup extends Resource
+{
+		protected $ignoreOnCreate = array(
+		  'id'
+		);
+		
+		protected $ignoreOnUpdate = array(
+		  'id'
+		);
+}

--- a/src/Bigcommerce/Api/Resources/Order.php
+++ b/src/Bigcommerce/Api/Resources/Order.php
@@ -16,9 +16,10 @@ class Order extends Resource
         return Client::getCollection('/orders/' . $this->id . '/shipments', 'Shipment');
     }
 
-    public function products()
+    public function products($filter = null)
     {
-        return Client::getCollection($this->fields->products->resource, 'OrderProduct');
+        $filter = Filter::create($filter);
+        return Client::getCollection($this->fields->products->resource . $filter->toQuery(), 'OrderProduct');
     }
 
     public function shipping_addresses()


### PR DESCRIPTION
Add the ability to apply filters to Order->products.  Allows settings limit and pagination.  The products call defaults to a limit of 50, so if an order has more than 50 products, you cannot get them without this change.

Issue #53 