### PR TITLE
CustomerGroup resource and query

### DIFF
--- a/src/Bigcommerce/Api/Client.php
+++ b/src/Bigcommerce/Api/Client.php
@@ -1045,6 +1045,17 @@ class Client
     }
 
     /**
+     * A single customer group by given id.
+     *
+     * @param int $id group id
+     * @return Resources\CustomerGroup
+     */
+    public static function getGroup($id)
+    {
+	    return self::getResource('/customer_groups/' . $id, 'CustomerGroup');
+    }
+
+    /**
      * Returns the collection of option sets.
      *
      * @param array $filter

--- a/src/Bigcommerce/Api/Resources/CustomerGroup.php
+++ b/src/Bigcommerce/Api/Resources/CustomerGroup.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Bigcommerce\Api\Resources;
+
+use Bigcommerce\Api\Resource;
+use Bigcommerce\Api\Client;
+
+class CustomerGroup extends Resource
+{
+    protected $ignoreOnCreate = array(
+        'id',
+    );
+
+    protected $ignoreOnUpdate = array(
+        'id',
+    );
+}


### PR DESCRIPTION
A "Customer" query returns a "customer_group_id".  The API allows querying the details of the CustomerGroup.  This patch adds support for the CustomerGroup query by id.
