### PR TITLE
Revert https://github.com/bigcommerce/bigcommerce-api-php/pull/155

### DIFF
--- a/src/Bigcommerce/Api/Connection.php
+++ b/src/Bigcommerce/Api/Connection.php
@@ -91,6 +91,9 @@ class Connection
      */
     public function __construct()
     {
+        if (!defined('STDIN')) {
+            define('STDIN', fopen('php://stdin', 'r'));
+        }
         $this->curl = curl_init();
         curl_setopt($this->curl, CURLOPT_HEADERFUNCTION, array($this, 'parseHeader'));
         curl_setopt($this->curl, CURLOPT_WRITEFUNCTION, array($this, 'parseBody'));
@@ -445,6 +448,7 @@ class Connection
         curl_exec($this->curl);
 
         fclose($handle);
+        curl_setopt($this->curl, CURLOPT_INFILE, STDIN);
 
         return $this->handleResponse();
     }


### PR DESCRIPTION
…e away, resetting to default

@aleachjr @PascalZajac 

What:
Reverting https://github.com/bigcommerce/bigcommerce-api-php/pull/155
and optionally define STDIN to address issues mentioned in same PR ^

Why:
Breaking basic tests
curl_exec(): CURLOPT_INFILE resource has gone away, resetting to default
FAILURES!
Tests: 70, Assertions: 476, Errors: 12.

Testing:
................................................................. 65 / 70 ( 92%)
.....
OK (70 tests, 541 assertions)