### PR TITLE
BIG-27111 Support for retrieving the customer login token

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,9 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "firebase/php-jwt": "~3.0",
+        "paragonie/random_compat": "~2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.*",

--- a/src/Bigcommerce/Api/Resources/Customer.php
+++ b/src/Bigcommerce/Api/Resources/Customer.php
@@ -34,4 +34,9 @@ class Customer extends Resource
     {
         return Client::deleteCustomer($this->id);
     }
+
+    public function getLoginToken()
+    {
+        return Client::getCustomerLoginUrl($this->id);
+    }
 }

--- a/test/Unit/Api/ClientTest.php
+++ b/test/Unit/Api/ClientTest.php
@@ -118,6 +118,36 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(5, Client::getLastError());
     }
 
+    public function testGetCustomerLoginTokenReturnsValidLoginToken()
+    {
+        Client::configureOAuth(array(
+            'client_id' => '123',
+            'auth_token' => 'def',
+            'store_hash' => 'abc',
+            'client_secret' => 'zyx'
+        ));
+        $expectedPayload = array(
+            'iss' => '123',
+            'operation' => 'customer_login',
+            'store_hash' => 'abc',
+            'customer_id' => 1,
+        );
+        $token = Client::getCustomerLoginToken(1);
+        $actualPayload = (array)\Firebase\JWT\JWT::decode($token, 'zyx', array('HS256'));
+        $this->assertArraySubset($expectedPayload, $actualPayload);
+    }
+
+    public function testGetCustomerLoginTokenThrowsIfNoClientSecret()
+    {
+        Client::configureOAuth(array(
+            'client_id' => '123',
+            'auth_token' => 'def',
+            'store_hash' => 'abc'
+        ));
+        $this->setExpectedException('\Exception', 'Cannot sign customer login tokens without a client secret');
+        Client::getCustomerLoginToken(1);
+    }
+
     public function testGetResourceReturnsSpecifiedType()
     {
         $this->connection->expects($this->once())


### PR DESCRIPTION
## What
Add support for the new customer login token generation mechanism.

## Why
Allow users to generate customer login tokens for SSO.

## Details
Because of the way the login mechanism works, a new optional configuration parameter called `client_secret` has been added. In order to generate login tokens, you must also have the "customer login" scope. This will be checked server side, so even if you attempt to generate tokens, they will be rejected so long as your credentials don't have the correct scopes.

@aleachjr @ICarpenter @bc-bfenton 

cc @bc-AlyssNoland @bookernath 