### PR TITLE
Added code for handling rate limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ composer.lock
 *.sh
 script/*
 
+# IDE
+.idea
+
 # Testing
 /phpunit.xml
 /build


### PR DESCRIPTION
I'm checking for status code 429 in the handleReponse() method, which indicates that the rate limit has been reached, and simply delaying and then repeating the request after the allotted time from the 'X-Retry-After' header returned in the response, up to a maximum of 3 times for now.  This has been tested locally using a script that generates over 9000 getTime() requests using OAuth authentication on a development store.