### PR TITLE
Updated connection.php with Jasper Studios fixes to resolve deadlocking

### DIFF
--- a/src/Bigcommerce/Api/Connection.php
+++ b/src/Bigcommerce/Api/Connection.php
@@ -365,6 +365,8 @@ class Connection
 
         curl_setopt($this->curl, CURLOPT_CUSTOMREQUEST, 'GET');
         curl_setopt($this->curl, CURLOPT_URL, $url);
+        curl_setopt($this->curl, CURLOPT_POST, false);
+        curl_setopt($this->curl, CURLOPT_PUT, false);
         curl_setopt($this->curl, CURLOPT_HTTPGET, true);
         curl_exec($this->curl);
 
@@ -392,6 +394,8 @@ class Connection
         curl_setopt($this->curl, CURLOPT_CUSTOMREQUEST, 'POST');
         curl_setopt($this->curl, CURLOPT_URL, $url);
         curl_setopt($this->curl, CURLOPT_POST, true);
+        curl_setopt($this->curl, CURLOPT_PUT, false);
+        curl_setopt($this->curl, CURLOPT_HTTPGET, false);
         curl_setopt($this->curl, CURLOPT_POSTFIELDS, $body);
         curl_exec($this->curl);
 
@@ -444,6 +448,8 @@ class Connection
 
         curl_setopt($this->curl, CURLOPT_CUSTOMREQUEST, 'PUT');
         curl_setopt($this->curl, CURLOPT_URL, $url);
+        curl_setopt($this->curl, CURLOPT_HTTPGET, false);
+        curl_setopt($this->curl, CURLOPT_POST, false);
         curl_setopt($this->curl, CURLOPT_PUT, true);
         curl_exec($this->curl);
 
@@ -463,6 +469,9 @@ class Connection
     {
         $this->initializeRequest();
 
+        curl_setopt($this->curl, CURLOPT_PUT, false);
+        curl_setopt($this->curl, CURLOPT_HTTPGET, false);
+        curl_setopt($this->curl, CURLOPT_POST, false);
         curl_setopt($this->curl, CURLOPT_CUSTOMREQUEST, 'DELETE');
         curl_setopt($this->curl, CURLOPT_URL, $url);
         curl_exec($this->curl);


### PR DESCRIPTION
http://www.jasperstudios.com/bigcommerce-api-code-patch/

> Namely, the biggest issue was that the official version did not properly handle the private CURL member object.  The CURL object referenced inside the big-commerce.php class is being reused in the POST, PUT, DELETE, and GET methods, and, after the use of each method the CURL member object simply was not being reset correctly.  More specifically, before it re-uses the CURL object for another call under the same initialization settings, it needed to reset old state flags.
> 
> Another issue we discovered was that API calls to the class involving the underlying PUT request was not properly closing a temporary file that had been opened just a few lines earlier.
> 
> The consequences of these bugs when attempting to make concurrent and chained requests inside the class when reusing the object were:
> 
> Deadlocks: the code would simply hang and block the PHP thread, shutting down our engine.
> Sporadic ‘Content Not Found’ Errors:  which seemingly happened randomly from time to time.
> The ‘sporadic’ errors weren’t so unpredictable after all, they resulted from a very specific series of call sequences to each HTTP type.  For example, a deadlock was ALWAYS reproduce-able when calling a POST method immediately after a PUT method.  If you didn’t call the code in exactly that order using the same static Bigcommerce instance you’d never observe this bug.