### PR TITLE
API-644 - Adding gzip support using the CURLOPT_ENCODING option

### DIFF
--- a/src/Bigcommerce/Api/Connection.php
+++ b/src/Bigcommerce/Api/Connection.php
@@ -98,6 +98,9 @@ class Connection
         curl_setopt($this->curl, CURLOPT_HEADERFUNCTION, array($this, 'parseHeader'));
         curl_setopt($this->curl, CURLOPT_WRITEFUNCTION, array($this, 'parseBody'));
 
+	// Set to a blank string to make cURL include all encodings it can handle (gzip, deflate, identity) in the 'Accept-Encoding' request header and respect the 'Content-Encoding' response header
+	curl_setopt($this->curl, CURLOPT_ENCODING, '');
+
         if (!ini_get("open_basedir")) {
             curl_setopt($this->curl, CURLOPT_FOLLOWLOCATION, true);
         } else {


### PR DESCRIPTION
**What?**

I am changing a PHP cURL setting so that requests made will include an 'Accept-Encoding' header with 'gzip' as one of it's accepted encodings.  This also allows the PHP cURL library to respect the 'Content-Encoding' response header and decode a 'gzip' response.

This change only effects people using oAuth credentials.


**Why?**

The purpose is to make the PHP API Library utilize gzip responses from our server without changing the way a Dev makes use of the library methods and classes.

**Testing/proof?**

When using the API library use the following code block after making a request to view it's response headers:

```
$r_headers = Bigcommerce::getConnection()->getHeaders();
foreach($r_headers as $key => $value){
 	echo "<p>" . $key . ": " . $value . "</p>";
}
``` 

You will see that, before this change, there is not a `Content-Encoding: gzip` response header included in the response.  After this update I see `Content-Encoding: gzip` in my response and that the `Content-Length` value is much smaller than from the same request before this change.