### PR TITLE
Fix the get auth token and update the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,27 @@ Bigcommerce::configure(array(
 ~~~
 
 ### OAuth
+
+In order to obtain the auth_token you would consume `Bigcommerce::getAuthToken` method 
+
 ~~~php
+
+$object = new \stdClass();
+$object->client_id = 'xxxxxx';
+$object->client_secret = 'xxxxx;
+$object->redirect_uri = 'https://app.com/redirect';
+$object->code = $request->get('code');
+$object->context = $request->get('context');
+$object->scope = $request->get('scope');
+
+$authTokenResponse = Bigcommerce::getAuthToken($object);
+
 Bigcommerce::configure(array(
     'client_id' => 'xxxxxxxx',
-    'auth_token' => 'xxxxxxx',
+    'auth_token' => $authTokenResponse->access_token,
     'store_hash' => 'xxxxxxx'
 ));
+
 ~~~
 
 Connecting to the store

--- a/src/Bigcommerce/Api/Client.php
+++ b/src/Bigcommerce/Api/Client.php
@@ -413,7 +413,6 @@ class Client
     {
         $context = array_merge(array('grant_type' => 'authorization_code'), (array)$object);
         $connection = new Connection();
-        $connection->useUrlEncoded();
 
         return $connection->post(self::$login_url . '/oauth2/token', $context);
     }


### PR DESCRIPTION
#### What?

Adding instructions on how to get the Auth Token when using OAuth and the SDK.

Remove the useUrlEncoded call when making getAuthToken as it results in passing the wrong content type to the API call.

#### Screenshots 

<img width="583" alt="screen shot 2017-03-05 at 1 40 26 pm" src="https://cloud.githubusercontent.com/assets/1681406/23584053/d8ab3670-01a9-11e7-88ef-9c67b03e92b3.png">
