### PR TITLE
Fix getHeader to be case-insensitive

### DIFF
--- a/src/Bigcommerce/Api/Connection.php
+++ b/src/Bigcommerce/Api/Connection.php
@@ -557,6 +557,13 @@ class Connection
         if (array_key_exists($header, $this->responseHeaders)) {
             return $this->responseHeaders[$header];
         }
+        foreach($this->responseHeaders as $k => $v)
+        {
+            if(strcasecmp($k, $header) == 0)
+            {
+                return $this->responseHeaders[$k];
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
#### What?

www.campman.com returns the  "X-BC-ApiLimit-Remaining" header in all lower-case, like "x-bc-apilimit-remaining".   The getRequestsRemaining API can not find the header, and always returns 0.  I patched the getHeader function so it will look for the header key using a case-insensitive search, if it can't find an exact match using the hash lookup.  Now, getRequestsRemaining returns the expected number of API requests remaining.  Note that [RFC2616](http://stackoverflow.com/questions/5258977/are-http-headers-case-sensitive) states that field names in the HTTP header are case-insensitive, so this is the correct thing to do.

#### Tickets / Documentation


#### Screenshots (if appropriate)

