### PR TITLE
Add shipping zone and method to client api

### DIFF
--- a/src/Bigcommerce/Api/Client.php
+++ b/src/Bigcommerce/Api/Client.php
@@ -1943,4 +1943,37 @@ class Client
     {
         return self::deleteResource('/hooks/' . $id);
     }
+
+    /**
+     * Return a collection of shipping-zones
+     *
+     * @return mixed
+     */
+    public static function getShippingZones()
+    {
+        return self::getCollection('/shipping/zones/', 'ShippingZone');
+    }
+
+    /**
+     * Return a shipping-zone by id
+     *
+     * @param int $id shipping-zone id
+     * @return mixed
+     */
+    public static function getShippingZone($id)
+    {
+        return self::getResource('/shipping/zones/' . $id, 'ShippingZone');
+    }
+
+
+    /**
+     * Delete the given shipping-zone
+     *
+     * @param int $id shipping-zone id
+     * @return mixed
+     */
+    public static function deleteShippingZone($id)
+    {
+        return self::deleteResource('/shipping/zones/' . $id);
+    }
 }

--- a/src/Bigcommerce/Api/Client.php
+++ b/src/Bigcommerce/Api/Client.php
@@ -1976,4 +1976,40 @@ class Client
     {
         return self::deleteResource('/shipping/zones/' . $id);
     }
+
+    /**
+     * Return a shipping-method by id
+     *
+     * @param $zoneId
+     * @param $methodId
+     * @return mixed
+     */
+    public static function getShippingMethod($zoneId, $methodId)
+    {
+        return self::getResource('/shipping/zones/'. $zoneId . '/methods/'. $methodId, 'ShippingMethod');
+    }
+
+    /**
+     * Return a collection of shipping-methods
+     *
+     * @param $zoneId
+     * @return mixed
+     */
+    public static function getShippingMethods($zoneId)
+    {
+        return self::getCollection('/shipping/zones/' . $zoneId . '/methods', 'ShippingMethod');
+    }
+
+
+    /**
+     * Delete the given shipping-method by id
+     *
+     * @param $zoneId
+     * @param $methodId
+     * @return mixed
+     */
+    public static function deleteShippingMethod($zoneId, $methodId)
+    {
+        return self::deleteResource('/shipping/zones/'. $zoneId . '/methods/'. $methodId);
+    }
 }

--- a/src/Bigcommerce/Api/Resources/ShippingMethod.php
+++ b/src/Bigcommerce/Api/Resources/ShippingMethod.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Bigcommerce\Api\Resources;
+
+use Bigcommerce\Api\Client;
+use Bigcommerce\Api\Resource;
+
+class ShippingMethod extends Resource
+{
+    protected $ignoreOnCreate = array(
+        'id',
+    );
+
+    protected $ignoreOnUpdate = array(
+        'id',
+    );
+
+    public function create($zoneId)
+    {
+        return Client::createResource('/shipping/zones/' . $zoneId . '/methods', $this->getCreateFields());
+    }
+
+    public function update($zoneId)
+    {
+        return Client::updateResource('/shipping/zones/' . $zoneId . '/methods/' . $this->id, $this->getUpdateFields());
+    }
+}

--- a/src/Bigcommerce/Api/Resources/ShippingZone.php
+++ b/src/Bigcommerce/Api/Resources/ShippingZone.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Bigcommerce\Api\Resources;
+
+use Bigcommerce\Api\Client;
+use Bigcommerce\Api\Resource;
+
+class ShippingZone extends Resource
+{
+    protected $ignoreOnCreate = array(
+        'id',
+    );
+
+    protected $ignoreOnUpdate = array(
+        'id',
+    );
+
+    public function create()
+    {
+        return Client::createResource('/shipping/zones/', $this->getCreateFields());
+    }
+
+    public function update()
+    {
+        return Client::updateResource('/shipping/zones/'. $this->id, $this->getUpdateFields());
+    }
+}

--- a/test/Unit/Api/Resources/ShippingMethodTest.php
+++ b/test/Unit/Api/Resources/ShippingMethodTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Bigcommerce\Test\Unit\Api\Resources;
+
+use Bigcommerce\Api\Client;
+use Bigcommerce\Api\Resources\ShippingMethod;
+
+class ShippingMethodTest extends ResourceTestBase
+{
+    public function testCreateShippingMethod()
+    {
+        $input = array(
+            "name" => "USPS Endicia",
+            "type" => "endicia",
+            "settings" => array(
+                "carrier_options" => array(
+                    "delivery_services" => array(
+                        "PriorityExpress",
+                        "PriorityMailExpressInternational",
+                        "FirstClassPackageInternationalService",
+                        "Priority",
+                        "PriorityMailInternational",
+                        "First",
+                        "ParcelSelect",
+                        "MediaMail"
+                    ),
+                    "packaging" => array(
+                        "FlatRateLegalEnvelope",
+                        "FlatRatePaddedEnvelope",
+                        "Parcel",
+                        "SmallFlatRateBox",
+                        "MediumFlatRateBox",
+                        "LargeFlatRateBox",
+                        "FlatRateEnvelope",
+                        "RegionalRateBoxA",
+                        "RegionalRateBoxB"
+                    ),
+                    "show_transit_time" => true,
+                )
+            ),
+            "enabled" => true
+        );
+        $method = new ShippingMethod((object)$input);
+        $this->connection->expects($this->once())
+            ->method('post')
+            ->with($this->basePath . '/shipping/zones/1/methods', (object)$input);
+
+        $method->create(1);
+    }
+
+    public function testUpdateShippingMethod()
+    {
+        $input = array(
+            "name" => "Ship by Weight",
+            "type" => "weight",
+            "settings" => array(
+                "default_cost" => 1,
+                "default_cost_type" => "fixed_amount",
+                "range" => array(
+                    array(
+                        "lower_limit" => 0,
+                        "upper_limit" => 20,
+                        "shipping_cost" => 8
+                    )
+                )
+            ),
+            "enabled" => true
+        );
+        $updateResource = array_merge(array('id' => 1), $input);
+        $method = new ShippingMethod((object)$updateResource);
+        $this->connection->expects($this->once())
+            ->method('put')
+            ->with($this->basePath . '/shipping/zones/1/methods/1', (object)$input);
+
+        $method->update(1);
+    }
+
+    public function testGetShippingMethod()
+    {
+        $this->connection->expects($this->once())
+            ->method('get')
+            ->with($this->basePath . '/shipping/zones/1/methods/2');
+
+        Client::getShippingMethod(1, 2);
+    }
+
+    public function testGetShippingMethods()
+    {
+        $this->connection->expects($this->once())
+            ->method('get')
+            ->with($this->basePath . '/shipping/zones/1/methods');
+
+        Client::getShippingMethods(1);
+    }
+
+    public function testDeleteShippingMethod()
+    {
+
+        $this->connection->expects($this->once())
+            ->method('delete')
+            ->with($this->basePath . '/shipping/zones/1/methods/2');
+
+        Client::deleteShippingMethod(1, 2);
+    }
+}

--- a/test/Unit/Api/Resources/ShippingZoneTest.php
+++ b/test/Unit/Api/Resources/ShippingZoneTest.php
@@ -33,7 +33,7 @@ class ShippingZoneTest extends ResourceTestBase
                 array('country_iso2' => 'US'),
             ),
         );
-        $updateResource = array_merge(['id' => 1], $input);
+        $updateResource = array_merge(array('id' => 1), $input);
         $zone = new ShippingZone((object)$updateResource);
 
         $this->connection->expects($this->once())

--- a/test/Unit/Api/Resources/ShippingZoneTest.php
+++ b/test/Unit/Api/Resources/ShippingZoneTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Bigcommerce\Test\Unit\Api\Resources;
+
+use Bigcommerce\Api\Client;
+use Bigcommerce\Api\Resources\ShippingZone;
+
+class ShippingZoneTest extends ResourceTestBase
+{
+    public function testCreateShippingZone()
+    {
+        $input = array(
+            'name' => 'United States',
+            'type' => 'country',
+            'locations' => array(
+                array('country_iso2' => 'US'),
+            ),
+        );
+        $zone = new ShippingZone((object)$input);
+        $this->connection->expects($this->once())
+            ->method('post')
+            ->with($this->basePath . '/shipping/zones/', (object)$input);
+
+        $zone->create();
+    }
+
+    public function testUpdateShippingZone()
+    {
+        $input = array(
+            'name' => 'United States',
+            'type' => 'country',
+            'locations' => array(
+                array('country_iso2' => 'US'),
+            ),
+        );
+        $updateResource = array_merge(['id' => 1], $input);
+        $zone = new ShippingZone((object)$updateResource);
+
+        $this->connection->expects($this->once())
+            ->method('put')
+            ->with($this->basePath . '/shipping/zones/1', (object)$input);
+
+        $zone->update();
+    }
+
+    public function testGetShippingZone()
+    {
+        $this->connection->expects($this->once())
+            ->method('get')
+            ->with($this->basePath . '/shipping/zones/1');
+
+        Client::getShippingZone(1);
+    }
+
+    public function testGetShippingZones()
+    {
+        $this->connection->expects($this->once())
+            ->method('get')
+            ->with($this->basePath . '/shipping/zones/');
+
+        Client::getShippingZones();
+    }
+
+    public function testDeleteShippingZone()
+    {
+
+        $this->connection->expects($this->once())
+            ->method('delete')
+            ->with($this->basePath . '/shipping/zones/1');
+
+        Client::deleteShippingZone(1);
+    }
+}


### PR DESCRIPTION
#### What?
Added support for shipping api V2 to:
- zones
- methods (static and real-time)

These resources allow stores to manage shipping configurations
For more details refer to API v2 doc https://developer.bigcommerce.com/api/v2/#api-v2-documentation and tickets mentioned below

#### Tickets / Documentation

- https://jira.bigcommerce.com/browse/PROJECT-1430
- https://jira.bigcommerce.com/browse/SHIPPING-8

