### PR TITLE
require paragonie/random_compat '~1.4|~2.0'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.3.0",
         "firebase/php-jwt": "~3.0",
-        "paragonie/random_compat": "~2.0"
+        "paragonie/random_compat": "~1.4|~2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.*",


### PR DESCRIPTION
#### What?

Allows `paragonie/random_compat: ~1.4|~2.0` instead of locking to `~2.0`. This is done for compatibility with other packages that require `~1.4`. All `2.0` updates are back-ported to `1.4`, so this should not cause any issues.

#### Tickets / Documentation
See the "Version Conflict with [Other PHP Project]" section in the `paragonie/random_compat` [README.](https://github.com/paragonie/random_compat#troubleshooting)