### PR TITLE
Change Rule->conditions To Use Fields

### DIFF
--- a/src/Bigcommerce/Api/Resources/Rule.php
+++ b/src/Bigcommerce/Api/Resources/Rule.php
@@ -22,12 +22,13 @@ class Rule extends Resource
 
     public function conditions()
     {
-        $conditions = Client::getCollection($this->fields->conditions->resource, 'RuleCondition');
-
-        foreach ($conditions as $condition) {
-            $condition->product_id = $this->product_id;
+        $conditions = array();
+        if (!isset($this->fields->conditions)) {
+            return $conditions;
         }
-
+        foreach ($this->fields->conditions as $condition) {
+            $conditions[] = new RuleCondition((object)$condition);
+        }
         return $conditions;
     }
 

--- a/test/Unit/Api/Resources/RuleTest.php
+++ b/test/Unit/Api/Resources/RuleTest.php
@@ -26,21 +26,27 @@ class RuleTest extends ResourceTestBase
         $rule->update();
     }
 
-    public function testConditionsPassesThroughToConnection()
+    public function testRuleHasConditions()
     {
         $rule = new Rule((object)array(
             'product_id' => 1,
-            'conditions' => (object)array('resource' => '/products/1/rules/1/conditions')
+            'conditions' => array(
+                array('option_value_id' => 1, 'product_option_id' => 1)
+            )
         ));
-        $this->connection->expects($this->once())
-            ->method('get')
-            ->with($this->basePath . '/products/1/rules/1/conditions')
-            ->will($this->returnValue(array(array(), array())));
 
-        $collection = $rule->conditions;
-        $this->assertInternalType('array', $collection);
-        foreach ($collection as $condition) {
-            $this->assertInstanceOf('Bigcommerce\\Api\\Resources\\RuleCondition', $condition);
-        }
+        $this->assertInstanceOf('Bigcommerce\Api\Resources\RuleCondition', $rule->conditions[0]);
+
+        $this->assertEquals(1, $rule->conditions[0]->option_value_id);
+        $this->assertEquals(1, $rule->conditions[0]->product_option_id);
+    }
+
+    public function testRuleHasNoConditions()
+    {
+        $rule = new Rule((object)array(
+            'product_id' => 1
+        ));
+
+        $this->assertEmpty($rule->conditions);
     }
 }


### PR DESCRIPTION
#### What?

This pull request is mostly a duplicate of #167 expect it also fixes the failed unit tests. The `Rule->conditions` method should act like the `Sku->options` method and not pull from a resource url.