### PR TITLE
Bump min PHP to 7.0, start running tests on 7.1 and 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: php
 php:
+- 7.2
+- 7.1
 - 7.0
-- 5.6
-- 5.5
-- 5.4
-- 5.3
 before_script:
 - composer install --dev --optimize-autoloader
 - mkdir -p build/logs

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ http://developer.bigcommerce.com/
 Requirements
 ------------
 
-- PHP 5.3 or greater
+- PHP 7.0 or greater
 - cUrl extension enabled
 
 **To connect to the API with basic auth you need the following:**

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=7.0",
         "firebase/php-jwt": "~3.0|~5.0",
         "paragonie/random_compat": "~1.4|~2.0"
     },


### PR DESCRIPTION
PHP 7.0 is the lowest supported version these days: http://php.net/supported-versions.php

Therefore, I've updated readmes and other things to remove support for anything lower.

I've also added 7.1 and 7.2 to Travis so we can start testing for compatibility with modern versions.