### PR TITLE
Fix the time test to compare the timestamps directly

### DIFF
--- a/test/Unit/Api/ClientTest.php
+++ b/test/Unit/Api/ClientTest.php
@@ -239,7 +239,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             ->with($this->basePath . '/time', false)
             ->will($this->returnValue((object)array('time' => $now->format('U'))));
 
-        $this->assertEquals($now, Client::getTime());
+        $this->assertEquals($now->format('U'), Client::getTime()->format('U'));
     }
 
     public function testGetStoreReturnsTheResultBodyDirectly()


### PR DESCRIPTION
#### What?

Fix the `Client::getTime` test to use timestamps, rather than comparing `DateTime` objects.
