### PR TITLE
random_compat needs only for php 5.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "firebase/php-jwt": "~3.0|~5.0",
-        "paragonie/random_compat": "~1.4|~2.0"
+        "firebase/php-jwt": "~3.0|~5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.*",


### PR DESCRIPTION
https://github.com/paragonie/random_compat needs only for php 5.x versions.
but `bigcommerce-api-php` requires php 7.x
php 7 no need polyfill (http://php.net/manual/en/book.csprng.php)