### PR TITLE
update endpoint for getShippingZones()

### DIFF
--- a/src/Bigcommerce/Api/Client.php
+++ b/src/Bigcommerce/Api/Client.php
@@ -1979,7 +1979,7 @@ class Client
      */
     public static function getShippingZones()
     {
-        return self::getCollection('/shipping/zones/', 'ShippingZone');
+        return self::getCollection('/shipping/zones', 'ShippingZone');
     }
 
     /**

--- a/test/Unit/Api/Resources/ShippingZoneTest.php
+++ b/test/Unit/Api/Resources/ShippingZoneTest.php
@@ -56,7 +56,7 @@ class ShippingZoneTest extends ResourceTestBase
     {
         $this->connection->expects($this->once())
             ->method('get')
-            ->with($this->basePath . '/shipping/zones/');
+            ->with($this->basePath . '/shipping/zones');
 
         Client::getShippingZones();
     }


### PR DESCRIPTION
removed trailing '/' from endpoint for getShippingZones() resulting in a 401 response

#### Tickets / Documentation

[#232 "401 response when calling getShippingZones()"](https://github.com/bigcommerce/bigcommerce-api-php/issues/232)