### PR TITLE
update getProductCustomFields() endpoint

### DIFF
--- a/src/Bigcommerce/Api/Client.php
+++ b/src/Bigcommerce/Api/Client.php
@@ -495,7 +495,7 @@ class Client
      */
     public static function getProductCustomFields($id)
     {
-        return self::getCollection('/products/' . $id . '/customfields/', 'ProductCustomField');
+        return self::getCollection('/products/' . $id . '/customfields', 'ProductCustomField');
     }
 
     /**

--- a/test/Unit/Api/ClientTest.php
+++ b/test/Unit/Api/ClientTest.php
@@ -449,7 +449,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     {
         $this->connection->expects($this->once())
             ->method('get')
-            ->with($this->basePath . '/products/1/customfields/', false)
+            ->with($this->basePath . '/products/1/customfields', false)
             ->will($this->returnValue(array(array(), array())));
 
         $collection = Client::getProductCustomFields(1);


### PR DESCRIPTION
removed trailing '/' from endpoint for getProductCustomFields() resulting in a 401 response

#### Tickets / Documentation

[#234 "401 response when calling getProductCustomFields()"](https://github.com/bigcommerce/bigcommerce-api-php/issues/234)