### PR TITLE
Update rate limit header to "X-Rate-Limit-Requests-Left"

### DIFF
--- a/src/Bigcommerce/Api/Client.php
+++ b/src/Bigcommerce/Api/Client.php
@@ -1336,7 +1336,7 @@ class Client
      */
     public static function getRequestsRemaining()
     {
-        $limit = self::connection()->getHeader('X-BC-ApiLimit-Remaining');
+        $limit = self::connection()->getHeader('X-Rate-Limit-Requests-Left');
 
         if (!$limit) {
             $result = self::getTime();
@@ -1345,7 +1345,7 @@ class Client
                 return false;
             }
 
-            $limit = self::connection()->getHeader('X-BC-ApiLimit-Remaining');
+            $limit = self::connection()->getHeader('X-Rate-Limit-Requests-Left');
         }
 
         return (int)$limit;


### PR DESCRIPTION
#### What?
Update getRequestsRemaining() header to "X-Rate-Limit-Requests-Left" to retrieve number of remaining requests available

#### Tickets / Documentation

Add links to any relevant tickets and documentation.
- [#236: "getRequestsRemaining() doesn't return number of API requests remaining"](https://github.com/bigcommerce/bigcommerce-api-php/issues/236)