### PR TITLE
Improvements: composer.json, coding style, PHPUnit and Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ script/*
 /build
 /test/reports
 .env
+/.php_cs
+/.php_cs.cache

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,11 @@
+<?php
+ return PhpCsFixer\Config::create()
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->files()
+            ->in(__DIR__ . '/src')
+            ->in(__DIR__ . '/test')
+    )
+    ->setRules([
+        '@PSR2' => true,
+    ]);

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,36 @@
+sudo: false
+
+cache:
+    directories:
+        - $HOME/.composer
+
+git:
+    depth: 1
+
 language: php
-php:
-- 7.2
-- 7.1
-- 7.0
-before_script:
-- composer install --dev --optimize-autoloader
-- mkdir -p build/logs
-after_script:
-- php vendor/bin/coveralls -v
-env:
-  global:
-  - secure: esQlDAcdxPtpwlOIFrC6d7/ejoOQyJJGeY/lhPv0qiWJ974+XxjLU7vGn0lKS5K4Z5WlZkGClEsfNok51Bm4JPnMsAZHTAO9f6bR7YpNrynmTyrwdv2NMUfAID8cJ9pUVZpbuT91M9aCuxUy4i2s+lx88myOVVr2r1YxQVcV1OA=
-  - secure: c9AOiucZTzzQu5QSLycx5CnQObIvkLiGrAv7yZg9gEouCDd3p4InOrW28WwMJjvVlTSN5BzEe1FLDh+rvatO2q4dwTTbx6NQ2QMTfM4W/L3M/Iv5yBt7VjuqlPXb4oHIvydvr/GXoRL/hNtn9wL/EdU5sKfSu+n0xVwsmCql/3U=
-  - secure: VKJgrYDePSIbdux5NodegW3vhLa3YSWLEkeTlScrGHBZVGK7K4F73s3v+32TeSNz/RYM8/MnSq2r9DUA7uPdms4UAWAFcz8uC36sOl1hkBy2gJAvYJJB5oLylR9TWXe+j20sDShdeGgfpFLcy/POcqdwQcJAx5XitDY4pw2ZwBI=
+
+before_install:
+    - composer self-update
+    - phpenv config-rm xdebug.ini || return 0
+    - composer global show hirak/prestissimo -q || composer global require hirak/prestissimo
+
+matrix:
+    include:
+        - name: PHP 7.0 with lowest versions of dependencies
+          php: '7.0'
+          install: composer update --prefer-lowest
+        - name: PHP 7.0
+          php: '7.0'
+          install: composer update
+        - name: PHP 7.1
+          php: '7.1'
+          install: composer update
+        - name: PHP 7.2
+          php: '7.2'
+          install: composer update
+          after_script:
+              - php vendor/bin/coveralls -v
+
+script:
+    - vendor/bin/php-cs-fixer fix --diff --dry-run -v
+    - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,13 @@
     "name": "bigcommerce/api",
     "type": "library",
     "description": "Enables PHP applications to communicate with the Bigcommerce API.",
-    "keywords": ["api", "http", "rest", "ecommerce", "business"],
+    "keywords": [
+        "api",
+        "http",
+        "rest",
+        "ecommerce",
+        "business"
+    ],
     "homepage": "http://developer.bigcommerce.com",
     "license": "MIT",
     "authors": [
@@ -13,12 +19,12 @@
     ],
     "require": {
         "php": ">=7.0",
-        "firebase/php-jwt": "~3.0|~5.0"
+        "firebase/php-jwt": "~3.0 || ~5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.35",
+        "codeless/jugglecode": "1.0",
         "php-coveralls/php-coveralls": "2.1",
-        "codeless/jugglecode": "1.0"
+        "phpunit/phpunit": "^4.8.35"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -29,12 +29,11 @@
     "autoload": {
         "psr-0": {
             "Bigcommerce": "src/"
-        },
+        }
+    },
+    "autoload-dev": {
         "psr-4": {
             "Bigcommerce\\Test\\": "test/"
         }
-    },
-    "scripts": {
-        "test": "phpunit"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     },
     "require-dev": {
         "codeless/jugglecode": "1.0",
+        "friendsofphp/php-cs-fixer": "^2.13",
         "php-coveralls/php-coveralls": "2.1",
         "phpunit/phpunit": "^4.8.35"
     },

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "codeless/jugglecode": "1.0",
         "friendsofphp/php-cs-fixer": "^2.13",
         "php-coveralls/php-coveralls": "2.1",
-        "phpunit/phpunit": "^4.8.35"
+        "phpunit/phpunit": "^6.4 || ^7.4"
     },
     "autoload": {
         "psr-0": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation='vendor/phpunit/phpunit/phpunit.xsd'
          backupGlobals="true"
          backupStaticAttributes="true"
          colors="true"
@@ -15,18 +15,15 @@
         <log type="coverage-php" target="build/logs/coverage.cov"/>
         <log type="coverage-text" target="build/logs/coverage.txt" showUncoveredFiles="false"/>
         <log type="coverage-html" target="test/reports/coverage/" showUncoveredFiles="true"/>
-        <log type="junit" target="test/reports/junit.xml" logIncompleteSkipped="false"/>
+        <log type="junit" target="test/reports/junit.xml"/>
     </logging>
     <testsuites>
-        <testsuite>
+        <testsuite name="test">
             <directory>test/</directory>
         </testsuite>
     </testsuites>
     <filter>
-        <blacklist>
-            <directory suffix=".php">vendor/</directory>
-        </blacklist>
-        <whitelist addUncoveredFilesFromWhitelist="true">
+        <whitelist>
             <directory suffix=".php">src/</directory>
         </whitelist>
     </filter>

--- a/src/Bigcommerce/Api/Client.php
+++ b/src/Bigcommerce/Api/Client.php
@@ -15,56 +15,56 @@ class Client
      *
      * @var string
      */
-    static private $store_url;
+    private static $store_url;
 
     /**
      * Username to connect to the store API with
      *
      * @var string
      */
-    static private $username;
+    private static $username;
 
     /**
      * API key
      *
      * @var string
      */
-    static private $api_key;
+    private static $api_key;
 
     /**
      * Connection instance
      *
      * @var Connection
      */
-    static private $connection;
+    private static $connection;
 
     /**
      * Resource class name
      *
      * @var string
      */
-    static private $resource;
+    private static $resource;
 
     /**
      * API path prefix to be added to store URL for requests
      *
      * @var string
      */
-    static private $path_prefix = '/api/v2';
+    private static $path_prefix = '/api/v2';
 
     /**
      * Full URL path to the configured store API.
      *
      * @var string
      */
-    static public $api_path;
-    static private $client_id;
-    static private $store_hash;
-    static private $auth_token;
-    static private $client_secret;
-    static private $stores_prefix = '/stores/%s/v2';
-    static private $api_url = 'https://api.bigcommerce.com';
-    static private $login_url = 'https://login.bigcommerce.com';
+    public static $api_path;
+    private static $client_id;
+    private static $store_hash;
+    private static $auth_token;
+    private static $client_secret;
+    private static $stores_prefix = '/stores/%s/v2';
+    private static $api_url = 'https://api.bigcommerce.com';
+    private static $login_url = 'https://login.bigcommerce.com';
 
     /**
      * Configure the API client with the required settings to access

--- a/src/Bigcommerce/Api/ClientError.php
+++ b/src/Bigcommerce/Api/ClientError.php
@@ -7,7 +7,6 @@ namespace Bigcommerce\Api;
  */
 class ClientError extends Error
 {
-
     public function __toString()
     {
         return "Client Error ({$this->code}): " . $this->message;

--- a/src/Bigcommerce/Api/Connection.php
+++ b/src/Bigcommerce/Api/Connection.php
@@ -340,7 +340,6 @@ class Connection
                 }
 
                 $this->get($url);
-
             } else {
                 $errorString = "Too many redirects when trying to follow location.";
                 throw new NetworkError($errorString, CURLE_TOO_MANY_REDIRECTS);

--- a/src/Bigcommerce/Api/Resources/Address.php
+++ b/src/Bigcommerce/Api/Resources/Address.php
@@ -7,5 +7,4 @@ use Bigcommerce\Api\Client;
 
 class Address extends Resource
 {
-
 }

--- a/src/Bigcommerce/Api/Resources/DiscountRule.php
+++ b/src/Bigcommerce/Api/Resources/DiscountRule.php
@@ -10,5 +10,4 @@ use Bigcommerce\Api\Client;
  */
 class DiscountRule extends Resource
 {
-
 }

--- a/src/Bigcommerce/Api/Resources/OrderCoupons.php
+++ b/src/Bigcommerce/Api/Resources/OrderCoupons.php
@@ -7,5 +7,4 @@ use Bigcommerce\Api\Client;
 
 class OrderCoupons extends Resource
 {
-
 }

--- a/src/Bigcommerce/Api/Resources/OrderProduct.php
+++ b/src/Bigcommerce/Api/Resources/OrderProduct.php
@@ -7,5 +7,4 @@ use Bigcommerce\Api\Client;
 
 class OrderProduct extends Resource
 {
-
 }

--- a/src/Bigcommerce/Api/Resources/OrderStatus.php
+++ b/src/Bigcommerce/Api/Resources/OrderStatus.php
@@ -7,5 +7,4 @@ use Bigcommerce\Api\Client;
 
 class OrderStatus extends Resource
 {
-
 }

--- a/src/Bigcommerce/Api/Resources/ProductConfigurableField.php
+++ b/src/Bigcommerce/Api/Resources/ProductConfigurableField.php
@@ -10,6 +10,4 @@ use Bigcommerce\Api\Client;
  */
 class ProductConfigurableField extends Resource
 {
-
 }
-

--- a/src/Bigcommerce/Api/Resources/ProductGoogleProductSearch.php
+++ b/src/Bigcommerce/Api/Resources/ProductGoogleProductSearch.php
@@ -10,5 +10,4 @@ use Bigcommerce\Api\Client;
  */
 class ProductGoogleProductSearch extends Resource
 {
-
 }

--- a/src/Bigcommerce/Api/Resources/ProductReview.php
+++ b/src/Bigcommerce/Api/Resources/ProductReview.php
@@ -10,5 +10,4 @@ use Bigcommerce\Api\Client;
  */
 class ProductReview extends Resource
 {
-
 }

--- a/src/Bigcommerce/Api/Resources/ProductVideo.php
+++ b/src/Bigcommerce/Api/Resources/ProductVideo.php
@@ -10,5 +10,4 @@ use Bigcommerce\Api\Client;
  */
 class ProductVideo extends Resource
 {
-
 }

--- a/src/Bigcommerce/Api/Resources/RequestLog.php
+++ b/src/Bigcommerce/Api/Resources/RequestLog.php
@@ -10,5 +10,4 @@ use Bigcommerce\Api\Client;
  */
 class RequestLog extends Resource
 {
-
 }

--- a/src/Bigcommerce/Api/Resources/TaxClass.php
+++ b/src/Bigcommerce/Api/Resources/TaxClass.php
@@ -10,5 +10,4 @@ use Bigcommerce\Api\Client;
  */
 class TaxClass extends Resource
 {
-
 }

--- a/test/Unit/Api/ClientErrorTest.php
+++ b/test/Unit/Api/ClientErrorTest.php
@@ -2,8 +2,9 @@
 namespace Bigcommerce\Unit\Api;
 
 use Bigcommerce\Api\ClientError;
+use PHPUnit\Framework\TestCase;
 
-class ClientErrorTest extends \PHPUnit_Framework_TestCase
+class ClientErrorTest extends TestCase
 {
     public function testStringifyingReturnsTheMessageAndCodeAppropriately()
     {

--- a/test/Unit/Api/ClientTest.php
+++ b/test/Unit/Api/ClientTest.php
@@ -424,13 +424,13 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
     public function testGettingProductGoogleProductSearch()
     {
-      $this->connection->expects($this->once())
+        $this->connection->expects($this->once())
           ->method('get')
           ->with($this->basePath . '/products/1/googleproductsearch')
           ->will($this->returnValue((object)array()));
 
-      $resource = Client::getGoogleProductSearch(1);
-      $this->assertInstanceOf('Bigcommerce\\Api\\Resources\\ProductGoogleProductSearch', $resource);
+        $resource = Client::getGoogleProductSearch(1);
+        $this->assertInstanceOf('Bigcommerce\\Api\\Resources\\ProductGoogleProductSearch', $resource);
     }
 
     public function testGettingProductImagesReturnsCollectionOfProductImages()

--- a/test/Unit/Api/ClientTest.php
+++ b/test/Unit/Api/ClientTest.php
@@ -4,8 +4,9 @@ namespace Bigcommerce\Test\Unit\Api;
 
 use Bigcommerce\Api\Client;
 use Bigcommerce\Api\Connection;
+use PHPUnit\Framework\TestCase;
 
-class ClientTest extends \PHPUnit_Framework_TestCase
+class ClientTest extends TestCase
 {
     /**
      * @var Connection|\PHPUnit_Framework_MockObject_MockObject
@@ -52,19 +53,22 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
     public function testConfigureRequiresStoreUrl()
     {
-        $this->setExpectedException('\\Exception', "'store_url' must be provided");
+        $this->expectException('\\Exception');
+        $this->expectExceptionMessage("'store_url' must be provided");
         Client::configure(array('username' => 'whatever', 'api_key' => 'whatever'));
     }
 
     public function testConfigureRequiresUsername()
     {
-        $this->setExpectedException('\\Exception', "'username' must be provided");
+        $this->expectException('\\Exception');
+        $this->expectExceptionMessage("'username' must be provided");
         Client::configure(array('store_url' => 'whatever', 'api_key' => 'whatever'));
     }
 
     public function testConfigureRequiresApiKey()
     {
-        $this->setExpectedException('\\Exception', "'api_key' must be provided");
+        $this->expectException('\\Exception');
+        $this->expectExceptionMessage("'api_key' must be provided");
         Client::configure(array('username' => 'whatever', 'store_url' => 'whatever'));
     }
 
@@ -144,7 +148,8 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             'auth_token' => 'def',
             'store_hash' => 'abc'
         ));
-        $this->setExpectedException('\Exception', 'Cannot sign customer login tokens without a client secret');
+        $this->expectException('\Exception');
+        $this->expectExceptionMessage('Cannot sign customer login tokens without a client secret');
         Client::getCustomerLoginToken(1);
     }
 
@@ -852,8 +857,8 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         Client::deleteAllGiftCertificates();
     }
-    
-    
+
+
     public function testGettingWebhooksReturnsAllWebhooks()
     {
         $this->connection->expects($this->once())
@@ -866,7 +871,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             $this->assertInstanceOf('Bigcommerce\\Api\\Resource', $resource);
         }
     }
-    
+
     public function testGettingSpecifiedWebhookReturnsTheSpecifiedWebhook()
     {
         $this->connection->expects($this->once())
@@ -876,7 +881,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $resource = Client::getWebhook(1);
         $this->assertInstanceOf('Bigcommerce\\Api\\Resource', $resource);
     }
-    
+
     public function testCreatingWebhookPostsToTheSpecifiedResource()
     {
         $this->connection->expects($this->once())
@@ -891,7 +896,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             ->with($this->basePath . '/hooks/1', (object)array());
         Client::updateWebhook(1, array());
     }
-    
+
     public function testDeleteWebhookDeletesToTheSpecifiedResource()
     {
         $this->connection->expects($this->once())

--- a/test/Unit/Api/ConnectionTest.php
+++ b/test/Unit/Api/ConnectionTest.php
@@ -3,8 +3,9 @@
 namespace Bigcommerce\Test\Unit;
 
 use Bigcommerce\Api\Connection;
+use PHPUnit\Framework\TestCase;
 
-class ConnectionTest extends \PHPUnit_Framework_TestCase
+class ConnectionTest extends TestCase
 {
     /**
      * @var \Bigcommerce\Api\Connection;

--- a/test/Unit/Api/ErrorTest.php
+++ b/test/Unit/Api/ErrorTest.php
@@ -2,8 +2,9 @@
 namespace Bigcommerce\Test\Unit;
 
 use Bigcommerce\Api\Error;
+use PHPUnit\Framework\TestCase;
 
-class ErrorTest extends \PHPUnit_Framework_TestCase
+class ErrorTest extends TestCase
 {
     public function testConstructorHandlesArrayOfMessageObjects()
     {

--- a/test/Unit/Api/FilterTest.php
+++ b/test/Unit/Api/FilterTest.php
@@ -2,8 +2,9 @@
 namespace Bigcommerce\Unit\Api;
 
 use Bigcommerce\Api\Filter;
+use PHPUnit\Framework\TestCase;
 
-class FilterTest extends \PHPUnit_Framework_TestCase
+class FilterTest extends TestCase
 {
     public function testToQueryBuildsAnAppropriateQueryString()
     {

--- a/test/Unit/Api/NetworkErrorTest.php
+++ b/test/Unit/Api/NetworkErrorTest.php
@@ -2,8 +2,9 @@
 namespace Bigcommerce\Unit\Api;
 
 use Bigcommerce\Api\NetworkError;
+use PHPUnit\Framework\TestCase;
 
-class NetworkErrorTest extends \PHPUnit_Framework_TestCase
+class NetworkErrorTest extends TestCase
 {
     public function testBehavesExactlyLikeException()
     {

--- a/test/Unit/Api/ResourceTest.php
+++ b/test/Unit/Api/ResourceTest.php
@@ -2,8 +2,9 @@
 namespace Bigcommerce\Test\Unit\Api;
 
 use Bigcommerce\Api\Resource;
+use PHPUnit\Framework\TestCase;
 
-class ResourceTest extends \PHPUnit_Framework_TestCase
+class ResourceTest extends TestCase
 {
     public function testGetCreateFieldsReturnsAllFieldsNotMarkedIgnore()
     {

--- a/test/Unit/Api/Resources/PageTest.php
+++ b/test/Unit/Api/Resources/PageTest.php
@@ -57,5 +57,4 @@ class PageTest extends ResourceTestBase
 
         $page->delete();
     }
-
 }

--- a/test/Unit/Api/Resources/ResourceTestBase.php
+++ b/test/Unit/Api/Resources/ResourceTestBase.php
@@ -3,8 +3,9 @@ namespace Bigcommerce\Test\Unit\Api\Resources;
 
 use Bigcommerce\Api\Client;
 use Bigcommerce\Api\Connection;
+use PHPUnit\Framework\TestCase;
 
-class ResourceTestBase extends \PHPUnit_Framework_TestCase
+class ResourceTestBase extends TestCase
 {
     /**
      * @var Connection|\PHPUnit_Framework_MockObject_MockObject

--- a/test/Unit/Api/Resources/ShippingMethodTest.php
+++ b/test/Unit/Api/Resources/ShippingMethodTest.php
@@ -95,7 +95,6 @@ class ShippingMethodTest extends ResourceTestBase
 
     public function testDeleteShippingMethod()
     {
-
         $this->connection->expects($this->once())
             ->method('delete')
             ->with($this->basePath . '/shipping/zones/1/methods/2');

--- a/test/Unit/Api/Resources/ShippingZoneTest.php
+++ b/test/Unit/Api/Resources/ShippingZoneTest.php
@@ -63,7 +63,6 @@ class ShippingZoneTest extends ResourceTestBase
 
     public function testDeleteShippingZone()
     {
-
         $this->connection->expects($this->once())
             ->method('delete')
             ->with($this->basePath . '/shipping/zones/1');

--- a/test/Unit/Api/ServerErrorTest.php
+++ b/test/Unit/Api/ServerErrorTest.php
@@ -2,8 +2,9 @@
 namespace Bigcommerce\Unit\Api;
 
 use Bigcommerce\Api\ServerError;
+use PHPUnit\Framework\TestCase;
 
-class ServerErrorTest extends \PHPUnit_Framework_TestCase
+class ServerErrorTest extends TestCase
 {
     public function testBehavesExactlyLikeException()
     {


### PR DESCRIPTION
This PR:
- [normalizes](https://github.com/localheinz/composer-normalize) `composer.json`
- removes unnecessary options from `composer.json`
- adds [PHP CS Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) and fixes code with it to follow PSR2
- upgrades PHPUnit to use v6/v7
- updates Travis CI configuration (similar as [here](https://github.com/bigcommerce/grphp/pull/21))