### PR TITLE
Use product custom fields endpoints form official documentation to stop random 401 status codes. 

### DIFF
--- a/src/Bigcommerce/Api/Client.php
+++ b/src/Bigcommerce/Api/Client.php
@@ -495,7 +495,7 @@ class Client
      */
     public static function getProductCustomFields($id)
     {
-        return self::getCollection('/products/' . $id . '/customfields', 'ProductCustomField');
+        return self::getCollection('/products/' . $id . '/custom_fields', 'ProductCustomField');
     }
 
     /**
@@ -506,7 +506,7 @@ class Client
      */
     public static function getProductCustomField($product_id, $id)
     {
-        return self::getResource('/products/' . $product_id . '/customfields/' . $id, 'ProductCustomField');
+        return self::getResource('/products/' . $product_id . '/custom_fields/' . $id, 'ProductCustomField');
     }
 
     /**
@@ -518,7 +518,7 @@ class Client
      */
     public static function createProductCustomField($product_id, $object)
     {
-        return self::createResource('/products/' . $product_id . '/customfields', $object);
+        return self::createResource('/products/' . $product_id . '/custom_fields', $object);
     }
 
     /**
@@ -542,7 +542,7 @@ class Client
      */
     public static function updateProductCustomField($product_id, $id, $object)
     {
-        return self::updateResource('/products/' . $product_id . '/customfields/' . $id, $object);
+        return self::updateResource('/products/' . $product_id . '/custom_fields/' . $id, $object);
     }
 
     /**
@@ -554,7 +554,7 @@ class Client
      */
     public static function deleteProductCustomField($product_id, $id)
     {
-        return self::deleteResource('/products/' . $product_id . '/customfields/' . $id);
+        return self::deleteResource('/products/' . $product_id . '/custom_fields/' . $id);
     }
 
     /**
@@ -1916,7 +1916,7 @@ class Client
             $object
         );
     }
-    
+
     /**
      * Returns all webhooks.
      *
@@ -1926,7 +1926,7 @@ class Client
     {
         return self::getCollection('/hooks');
     }
-    
+
     /**
      * Returns data for a specific web-hook.
      *
@@ -1937,7 +1937,7 @@ class Client
     {
         return self::getResource('/hooks/' . $id);
     }
-    
+
     /**
      * Creates a web-hook.
      *
@@ -1948,7 +1948,7 @@ class Client
     {
         return self::createResource('/hooks', $object);
     }
-    
+
     /**
      * Updates the given webhook.
      *
@@ -1960,7 +1960,7 @@ class Client
     {
         return self::updateResource('/hooks/' . $id, $object);
     }
-    
+
     /**
      * Delete the given webhook.
      *
@@ -2040,7 +2040,7 @@ class Client
     {
         return self::deleteResource('/shipping/zones/'. $zoneId . '/methods/'. $methodId);
     }
-    
+
     /**
      * Get collection of product skus by Product
      *

--- a/test/Unit/Api/ClientTest.php
+++ b/test/Unit/Api/ClientTest.php
@@ -449,7 +449,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     {
         $this->connection->expects($this->once())
             ->method('get')
-            ->with($this->basePath . '/products/1/customfields', false)
+            ->with($this->basePath . '/products/1/custom_fields', false)
             ->will($this->returnValue(array(array(), array())));
 
         $collection = Client::getProductCustomFields(1);
@@ -474,7 +474,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     {
         $this->connection->expects($this->once())
             ->method('get')
-            ->with($this->basePath . '/products/1/customfields/1', false)
+            ->with($this->basePath . '/products/1/custom_fields/1', false)
             ->will($this->returnValue(array(array(), array())));
 
         $resource = Client::getProductCustomField(1, 1);
@@ -560,7 +560,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     {
         $this->connection->expects($this->once())
             ->method('post')
-            ->with($this->basePath . '/products/1/customfields', (object)array());
+            ->with($this->basePath . '/products/1/custom_fields', (object)array());
 
         Client::createProductCustomField(1, array());
     }
@@ -578,7 +578,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     {
         $this->connection->expects($this->once())
             ->method('put')
-            ->with($this->basePath . '/products/1/customfields/1', (object)array());
+            ->with($this->basePath . '/products/1/custom_fields/1', (object)array());
 
         Client::updateProductCustomField(1, 1, array());
     }
@@ -596,7 +596,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     {
         $this->connection->expects($this->once())
             ->method('delete')
-            ->with($this->basePath . '/products/1/customfields/1');
+            ->with($this->basePath . '/products/1/custom_fields/1');
 
         Client::deleteProductCustomField(1, 1);
     }
@@ -852,8 +852,8 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         Client::deleteAllGiftCertificates();
     }
-    
-    
+
+
     public function testGettingWebhooksReturnsAllWebhooks()
     {
         $this->connection->expects($this->once())
@@ -866,7 +866,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             $this->assertInstanceOf('Bigcommerce\\Api\\Resource', $resource);
         }
     }
-    
+
     public function testGettingSpecifiedWebhookReturnsTheSpecifiedWebhook()
     {
         $this->connection->expects($this->once())
@@ -876,7 +876,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $resource = Client::getWebhook(1);
         $this->assertInstanceOf('Bigcommerce\\Api\\Resource', $resource);
     }
-    
+
     public function testCreatingWebhookPostsToTheSpecifiedResource()
     {
         $this->connection->expects($this->once())
@@ -891,7 +891,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             ->with($this->basePath . '/hooks/1', (object)array());
         Client::updateWebhook(1, array());
     }
-    
+
     public function testDeleteWebhookDeletesToTheSpecifiedResource()
     {
         $this->connection->expects($this->once())


### PR DESCRIPTION
#### What?

Fixed product custom field methods to use the correct v2 endpoints. `/customfields/` gives a 401 status code. The documentation uses `/custom_fields`. It should be noted that `/customfields` (no trailing slash) returns a 200 status code.

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [BC custom field documentation](https://developer.bigcommerce.com/api/v2/#list-custom-fields)

#### Screenshots (if appropriate)

NA
