### PR TITLE
Fix getHeader to be case-insensitive

### DIFF
--- a/src/Bigcommerce/Api/Connection.php
+++ b/src/Bigcommerce/Api/Connection.php
@@ -557,8 +557,8 @@ class Connection
             return $this->responseHeaders[$header];
         }
         // Do case-insensitive search
-        foreach($this->responseHeaders as $k => $v) {
-            if(strtolower($k) == strtolower($header)) {
+        foreach ($this->responseHeaders as $k => $v) {
+            if (strtolower($k) == strtolower($header)) {
                 return $v;
             }
         }

--- a/src/Bigcommerce/Api/Connection.php
+++ b/src/Bigcommerce/Api/Connection.php
@@ -556,6 +556,12 @@ class Connection
         if (array_key_exists($header, $this->responseHeaders)) {
             return $this->responseHeaders[$header];
         }
+        // Do case-insensitive search
+        foreach($this->responseHeaders as $k => $v) {
+            if(strtolower($k) == strtolower($header)) {
+                return $v;
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
On certain BigCommerce stores, getHeader fails because the X-BC-ApiLimit-Remaining header is all lower-case in the HTTP response.  This causes getRequestsRemaining to always return 0 and puts the code into an infinite wait for more requests.  Instead, change getHeader to do a case-insensitive search for the header if the exact case is not found.  Please merge this into the trunk.  The code keeps breaking every time I update the library.

I had created a previous pull request to fix this, but I don't think it got fixed:
https://github.com/bigcommerce/bigcommerce-api-php/pull/196