### PR TITLE
Fixes #223

### DIFF
--- a/src/Bigcommerce/Api/Connection.php
+++ b/src/Bigcommerce/Api/Connection.php
@@ -286,14 +286,14 @@ class Connection
 
         if ($status >= 400 && $status <= 499) {
             if ($this->failOnError) {
-                throw new ClientError($body, $status);
+                throw new ClientError(strval($body), $status);
             } else {
                 $this->lastError = $body;
                 return false;
             }
         } elseif ($status >= 500 && $status <= 599) {
             if ($this->failOnError) {
-                throw new ServerError($body, $status);
+                throw new ServerError(strval($body), $status);
             } else {
                 $this->lastError = $body;
                 return false;


### PR DESCRIPTION
#### What?

Some responses incorrectly throw error messages because there is a type mismatch on the arguments to the error constructors.  Basically, `json_decode` on the response body is not guaranteed to return a string.  We need to enforce the string.

Writing test cases involved a lot of work unless a curl abstraction was built/used.  Even mocking is extremely difficult here.

#### Tickets / Documentation

https://github.com/bigcommerce/bigcommerce-api-php/issues/223

#### Screenshots (if appropriate)

None

cc @jofomah