### PR TITLE
Namespace update for not complying with psr-4 autoloading standard

### DIFF
--- a/test/Unit/Api/ConnectionTest.php
+++ b/test/Unit/Api/ConnectionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace bigcommerce\test\unit;
+namespace Bigcommerce\test\unit;
 
 use Bigcommerce\Api\Connection;
 use PHPUnit\Framework\TestCase;

--- a/test/Unit/Api/ConnectionTest.php
+++ b/test/Unit/Api/ConnectionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Bigcommerce\test\Unit;
+namespace Bigcommerce\test\Unit\Api;
 
 use Bigcommerce\Api\Connection;
 use PHPUnit\Framework\TestCase;

--- a/test/Unit/Api/ConnectionTest.php
+++ b/test/Unit/Api/ConnectionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Bigcommerce\Test\Unit;
+namespace bigcommerce\test\unit;
 
 use Bigcommerce\Api\Connection;
 use PHPUnit\Framework\TestCase;

--- a/test/Unit/Api/ConnectionTest.php
+++ b/test/Unit/Api/ConnectionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Bigcommerce\test\unit;
+namespace Bigcommerce\test\Unit;
 
 use Bigcommerce\Api\Connection;
 use PHPUnit\Framework\TestCase;

--- a/test/Unit/Api/ErrorTest.php
+++ b/test/Unit/Api/ErrorTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Bigcommerce\test\Unit;
+namespace Bigcommerce\test\Unit\Api;
 
 use Bigcommerce\Api\Error;
 use PHPUnit\Framework\TestCase;

--- a/test/Unit/Api/ErrorTest.php
+++ b/test/Unit/Api/ErrorTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Bigcommerce\Test\Unit;
+namespace bigcommerce\test\unit;
 
 use Bigcommerce\Api\Error;
 use PHPUnit\Framework\TestCase;

--- a/test/Unit/Api/ErrorTest.php
+++ b/test/Unit/Api/ErrorTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Bigcommerce\test\unit;
+namespace Bigcommerce\test\Unit;
 
 use Bigcommerce\Api\Error;
 use PHPUnit\Framework\TestCase;

--- a/test/Unit/Api/ErrorTest.php
+++ b/test/Unit/Api/ErrorTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace bigcommerce\test\unit;
+namespace Bigcommerce\test\unit;
 
 use Bigcommerce\Api\Error;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
#### What?

It would be better to have a clean `composer dumpautoload` **without** having any warning right?
This is a partial fix for the two errors in my screenshot based from psr-4.

#### Tickets

- [268](https://github.com/bigcommerce/bigcommerce-api-php/issues/268)

#### Screenshot

https://prnt.sc/ytbe1q
