### PR TITLE
fix(curl): Add CURLOPT_USERAGENT to all requests

### DIFF
--- a/src/Bigcommerce/Api/Connection.php
+++ b/src/Bigcommerce/Api/Connection.php
@@ -97,6 +97,7 @@ class Connection
         $this->curl = curl_init();
         curl_setopt($this->curl, CURLOPT_HEADERFUNCTION, [$this, 'parseHeader']);
         curl_setopt($this->curl, CURLOPT_WRITEFUNCTION, [$this, 'parseBody']);
+        curl_setopt($this->curl, CURLOPT_USERAGENT, 'PHP CURL - Bigcommerce API Client');
 
         // Set to a blank string to make cURL include all encodings it can handle (gzip, deflate, identity) in the 'Accept-Encoding' request header and respect the 'Content-Encoding' response header
         curl_setopt($this->curl, CURLOPT_ENCODING, '');


### PR DESCRIPTION
#### What?

User agent is no longer present when making the requests, this causes some
of them to fail

#### Screenshots (if appropriate)
Before: 
<img width="537" alt="image" src="https://user-images.githubusercontent.com/4542735/140004115-7e96ff5b-520d-4861-9069-124c263278f9.png">

After:
<img width="263" alt="image" src="https://user-images.githubusercontent.com/4542735/140004102-c7ba1faa-e020-4447-ae43-0b94446e37fb.png">

@bigcommerce/husky 