### PR TITLE
Upcoming changes to HTTP header casing

### DIFF
--- a/src/Bigcommerce/Api/Client.php
+++ b/src/Bigcommerce/Api/Client.php
@@ -1336,7 +1336,10 @@ class Client
      */
     public static function getRequestsRemaining()
     {
-        $limit = self::connection()->getHeader('X-Rate-Limit-Requests-Left');
+        //See https://developer.bigcommerce.com/changelog#publications/upcoming-changes-to-http-header-casing
+        $limit = self::connection()->getHeader('x-rate-limit-requests-left')
+            ? self::connection()->getHeader('x-rate-limit-requests-left')
+            : self::connection()->getHeader('X-Rate-Limit-Requests-Left');
 
         if (!$limit) {
             $result = self::getTime();
@@ -1345,7 +1348,9 @@ class Client
                 return false;
             }
 
-            $limit = self::connection()->getHeader('X-Rate-Limit-Requests-Left');
+            $limit = self::connection()->getHeader('x-rate-limit-requests-left')
+                ? self::connection()->getHeader('x-rate-limit-requests-left')
+                : self::connection()->getHeader('X-Rate-Limit-Requests-Left');
         }
 
         return (int)$limit;


### PR DESCRIPTION


#### What?

For example, HTTP header names such as `X-Rate-Limit-Requests-Left` may instead be returned as `x-rate-limit-requests-left`. Per the HTTP specification (https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2), HTTP header names should always be treated as case-insensitive, so we do not consider this to be a breaking change to the API.


#### Tickets / Documentation


- [Upcoming Developer BigCommerce Changelog](https://developer.bigcommerce.com/changelog#publications/upcoming-changes-to-http-header-casing)


#### Screenshots (if appropriate)

![BigCommerce-HTTP-Header-Casing-Change](https://user-images.githubusercontent.com/49310430/149603068-04941a22-7138-44ea-ae2e-6877e8d38a0a.png)

