### PR TITLE
Add api_url and login_url config options

### DIFF
--- a/.phpstan/baseline.neon
+++ b/.phpstan/baseline.neon
@@ -1,11 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Call to function is_string\\(\\) with stdClass will always evaluate to false\\.$#"
-			count: 2
-			path: ../src/Bigcommerce/Api/Client.php
-
-		-
 			message: "#^Method Bigcommerce\\\\Api\\\\Client\\:\\:createCoupon\\(\\) has parameter \\$object with no type specified\\.$#"
 			count: 1
 			path: ../src/Bigcommerce/Api/Client.php
@@ -497,11 +492,6 @@ parameters:
 
 		-
 			message: "#^Method Bigcommerce\\\\Api\\\\Filter\\:\\:__construct\\(\\) has parameter \\$filter with no type specified\\.$#"
-			count: 1
-			path: ../src/Bigcommerce/Api/Filter.php
-
-		-
-			message: "#^Method Bigcommerce\\\\Api\\\\Filter\\:\\:__set\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: ../src/Bigcommerce/Api/Filter.php
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "ext-curl": "*"
     },
     "require-dev": {
-        "codeless/jugglecode": "1.0",
         "friendsofphp/php-cs-fixer": "^3.13",
         "php-coveralls/php-coveralls": "2.5",
         "phpunit/phpunit": "^9.5",

--- a/src/Bigcommerce/Api/Client.php
+++ b/src/Bigcommerce/Api/Client.php
@@ -115,6 +115,14 @@ class Client
             throw new Exception("'store_hash' must be provided");
         }
 
+        if (isset($settings['api_url'])) {
+            self::$api_url = $settings['api_url'];
+        }
+
+        if (isset($settings['login_url'])) {
+            self::$login_url = $settings['login_url'];
+        }
+
         self::$client_id = $settings['client_id'];
         self::$auth_token = $settings['auth_token'];
         self::$store_hash = $settings['store_hash'];

--- a/src/Bigcommerce/Api/Client.php
+++ b/src/Bigcommerce/Api/Client.php
@@ -398,8 +398,8 @@ class Client
      * Map a single object to a resource class.
      *
      * @param string $resource name of the resource class
-     * @param \stdClass $object
-     * @return Resource
+     * @param \stdClass|boolean|string $object
+     * @return bool|\stdClass|string
      */
     private static function mapResource($resource, $object)
     {
@@ -415,8 +415,8 @@ class Client
     /**
      * Map object representing a count to an integer value.
      *
-     * @param \stdClass $object
-     * @return int
+     * @param \stdClass|boolean|string $object
+     * @return int|boolean
      */
     private static function mapCount($object)
     {

--- a/test/Unit/Api/ClientTest.php
+++ b/test/Unit/Api/ClientTest.php
@@ -1084,4 +1084,22 @@ class ClientTest extends TestCase
 
         Client::updateOptionValue(1, 1, array());
     }
+
+    public function testConnectionUsesApiUrlOverride()
+    {
+        $this->connection->expects($this->once())
+            ->method('get')
+            ->with('https://api.url.com/time');
+
+        Client::configureOAuth([
+            'client_id' => '123',
+            'auth_token' => '123xyz',
+            'store_hash' => 'abc123',
+            'api_url' => 'https://api.url.com',
+            'login_url' => 'https://login.url.com',
+        ]);
+        Client::setConnection($this->connection); // re-set the connection since Client::setConnection unsets it
+
+        Client::getTime();
+    }
 }


### PR DESCRIPTION
#### What?

- Adds the ability to override `api_url` and `login_url` as part of the oAuth flow.
- Removes the stale codeless/jugglecode dependency as it seems it no longer exists and composer fails trying to fetch it (https://github.com/codeless/JuggleCode is a 404)
- phpstan was complaining about a few things in the file I edited, so I tweaked some type docs to fix it, which in turn made some of the baseline neon definitions not applicable anymore. Seems reasonable to me, but LMK if a preferred method exists


#### Screenshots (if appropriate)

No screenshots to attach, but I have tested these changes in my consumer app via `composer require "bigcommerce/api @dev"` and verified the right URLs are being used:

If no custom URLs are provided, `https://api.bigcommerce.com` and `https://login.bigcommerce.com` are used.
If custom URLs are provided, those are being used
