### PR TITLE
Fix Client::getTime()

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ https://developer.bigcommerce.com/
 Requirements
 ------------
 
-- PHP 7.1 or greater
+- PHP 8.1 or greater
 - `curl` extension enabled
 
 To generate an OAuth API token, [follow this guide.](https://support.bigcommerce.com/s/article/Store-API-Accounts)
@@ -96,12 +96,12 @@ Connecting to the store
 -----------------------
 
 To test that your configuration was correct and you can successfully connect to
-the store, ping the getTime method which will return a DateTime object
-representing the current timestamp of the store if successful or false if
+the store, ping the getStoreTime method which will return a DateTime object
+representing the current timestamp of the store if successful or null if
 unsuccessful:
 
 ~~~php
-$ping = Bigcommerce::getTime();
+$ping = Bigcommerce::getStoreTime();
 
 if ($ping) echo $ping->format('H:i:s');
 ~~~

--- a/src/Bigcommerce/Api/Client.php
+++ b/src/Bigcommerce/Api/Client.php
@@ -474,7 +474,7 @@ class Client
     }
 
     /**
-     * Pings the time endpoint to test the connection to a store.
+     * Pings the time endpoint to test the connection to the BigCommerce API.
      *
      * @return ?DateTime
      */
@@ -486,7 +486,9 @@ class Client
             return null;
         }
 
-        return new DateTime("@{$response}");
+        $seconds = floor($response / 1000);
+        $microseconds = $response % 1000;
+        return DateTime::createFromFormat('U.u', sprintf('%d.%03d', $seconds, $microseconds));
     }
 
     /**

--- a/src/Bigcommerce/Api/Client.php
+++ b/src/Bigcommerce/Api/Client.php
@@ -488,8 +488,8 @@ class Client
 
         // The response from /time is unix time in milliseconds
         $seconds = floor($response / 1000);
-        $microseconds = $response % 1000;
-        return DateTime::createFromFormat('U.u', sprintf('%d.%03d', $seconds, $microseconds));
+        $milliseconds = $response % 1000;
+        return DateTime::createFromFormat('U.u', sprintf('%d.%03d', $seconds, $milliseconds));
     }
 
     /**

--- a/src/Bigcommerce/Api/Client.php
+++ b/src/Bigcommerce/Api/Client.php
@@ -482,13 +482,30 @@ class Client
     {
         $response = self::connection()->get(self::$api_url . '/time');
 
-        if (empty($response)) {
+        if (empty($response) || !is_numeric($response)) {
             return null;
         }
 
+        // The response from /time is unix time in milliseconds
         $seconds = floor($response / 1000);
         $microseconds = $response % 1000;
         return DateTime::createFromFormat('U.u', sprintf('%d.%03d', $seconds, $microseconds));
+    }
+
+    /**
+     * Pings the time endpoint to test the connection to a store.
+     *
+     * @return ?DateTime
+     */
+    public static function getStoreTime()
+    {
+        $response = self::connection()->get(self::$api_path . '/time');
+
+        if (!is_object($response) || !property_exists($response, 'time')) {
+            return null;
+        }
+
+        return new DateTime("@{$response->time}");
     }
 
     /**

--- a/test/Unit/Api/ClientTest.php
+++ b/test/Unit/Api/ClientTest.php
@@ -206,13 +206,32 @@ class ClientTest extends TestCase
 
     public function testGetTimeReturnsTheExpectedTime()
     {
-        $now = new \DateTime();
         $this->connection->expects($this->once())
             ->method('get')
             ->with('https://api.bigcommerce.com/time', false)
             ->will($this->returnValue('1718283600000'));
 
         $this->assertEquals('2024-06-13 13:00:00', Client::getTime()->format('Y-m-d H:i:s'));
+    }
+
+    public function testGetStoreTimeReturnsTheExpectedTime()
+    {
+        $this->connection->expects($this->once())
+            ->method('get')
+            ->with($this->basePath . '/time')
+            ->will($this->returnValue(json_decode('{"time": 1718283600}')));
+
+        $this->assertEquals('2024-06-13 13:00:00', Client::getStoreTime()->format('Y-m-d H:i:s'));
+    }
+
+    public function testGetStoreTimeReturnsNothing()
+    {
+        $this->connection->expects($this->once())
+            ->method('get')
+            ->with($this->basePath . '/time')
+            ->will($this->returnValue(false));
+
+        $this->assertEquals(null, Client::getStoreTime());
     }
 
     public function testGetStoreReturnsTheResultBodyDirectly()

--- a/test/Unit/Api/ClientTest.php
+++ b/test/Unit/Api/ClientTest.php
@@ -210,9 +210,9 @@ class ClientTest extends TestCase
         $this->connection->expects($this->once())
             ->method('get')
             ->with('https://api.bigcommerce.com/time', false)
-            ->will($this->returnValue($now->format('U')));
+            ->will($this->returnValue('1718283600000'));
 
-        $this->assertEquals($now->format('U'), Client::getTime()->format('U'));
+        $this->assertEquals('2024-06-13 13:00:00', Client::getTime()->format('Y-m-d H:i:s'));
     }
 
     public function testGetStoreReturnsTheResultBodyDirectly()


### PR DESCRIPTION
## What/Why?
Fixes #298

- Updates Client::getTime() to expect time in milliseconds as that's [the response from /time](https://api.bigcommerce.com/time)
- Adds Client::getStoreTime() which queries https://api.bigcommerce.com/stores/{{storeHash}}/v2/time. That requires authentication so this method can be used to verify that the client is configured correctly
- Update README to reflect changes

## Testing

_**Updated `::getTime()`**_
I've updated the unit test to reflect what's actually returned by the API. Also I've run the steps provided to reproduce this issue, verifying that it no longer happens:

```
php > var_dump(\Bigcommerce\Api\Client::getTime());
php shell code:1:
class DateTime#6 (3) {
  public $date =>
  string(26) "2024-06-13 13:43:56.124000"
  public $timezone_type =>
  int(1)
  public $timezone =>
  string(6) "+00:00"
}
```


_**Added `::getStoreTime()`**_
```
php > var_dump(\Bigcommerce\Api\Client::getStoreTime());
php shell code:1:
class DateTime#7 (3) {
  public $date =>
  string(26) "2024-06-14 09:01:35.000000"
  public $timezone_type =>
  int(1)
  public $timezone =>
  string(6) "+00:00"
}
```