### PR TITLE
chore(search): ES-5745 Prevent null message passed to ServerError

### DIFF
--- a/src/Bigcommerce/Api/Connection.php
+++ b/src/Bigcommerce/Api/Connection.php
@@ -330,7 +330,7 @@ class Connection
             }
         } elseif ($status >= 500 && $status <= 599) {
             if ($this->failOnError) {
-                throw new ServerError($body, $status, $this->responseHeaders);
+                throw new ServerError($body ?? '', $status, $this->responseHeaders);
             } else {
                 $this->lastError = $body;
                 return false;


### PR DESCRIPTION
#### What?
This PR prevents:
`Passing null to parameter #1 ($message) of type string is deprecated`

#### Tickets / Documentation
[ES-5745](https://bigcommercecloud.atlassian.net/browse/ES-5745?atlOrigin=eyJpIjoiY2FmNDQyNWQxYThlNGQzYzk0ZTllMTc4YWRiZWExODciLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

#### Testing
Test is passing now:
Faceted Search Category List HTTP (Bigcommerce\Tests\Functional\Tests\StorefrontPlatform\Resources\Search\Faceted_search\FacetedSearchCategoryListHTTP)
 ✔ Two products in parent category with current and child category listing mode settings

OK (1 test, 47 assertions)
Functional Tests complete


[ES-5745]: https://bigcommercecloud.atlassian.net/browse/ES-5745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ