### PR TITLE
Add PHP 8.5 to CircleCI matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
   ci: bigcommerce/internal@volatile
   php: bigcommerce/internal-php@volatile
 
-define: &php_min "8.1"
+define: &php_min "8.2"
 
 jobs_default: &jobs_default
   e:
@@ -12,7 +12,7 @@ jobs_default: &jobs_default
     php-version: << matrix.php-version >>
   matrix:
     parameters:
-      php-version: [ *php_min, "8.2", "8.3" , "8.4" ]
+      php-version: [ *php_min, "8.3", "8.4", "8.5" ]
 
 jobs:
   cs-fixer:

--- a/src/Bigcommerce/Api/Connection.php
+++ b/src/Bigcommerce/Api/Connection.php
@@ -622,14 +622,4 @@ class Connection
     {
         return $this->responseHeadersList;
     }
-
-    /**
-     * Close the cURL resource when the instance is garbage collected
-     */
-    public function __destruct()
-    {
-        if ($this->curl !== null) {
-            curl_close($this->curl);
-        }
-    }
 }


### PR DESCRIPTION
## What/Why?
- Add PHP 8.5 to CircleCI matrix
- Remove PHP 8.1 from CircleCI matrix because it's EOL
- Fix PHP 8.5 deprecation warning `Deprecated: Function curl_close() is deprecated since 8.5, as it has no effect since PHP 8.0`