### PR TITLE
fix: PHPMNT-347 allow firebase/php-jwt ^7.0 to fix CVE-2025-45769

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "firebase/php-jwt": "~5.0 || ~6.0",
+        "firebase/php-jwt": "~5.0 || ~6.0 || ^7.0",
         "ext-curl": "*"
     },
     "require-dev": {

--- a/test/Unit/Api/ClientTest.php
+++ b/test/Unit/Api/ClientTest.php
@@ -103,10 +103,11 @@ class ClientTest extends TestCase
 
     public function testGetCustomerLoginTokenReturnsValidLoginToken()
     {
-        Client::configureOAuth(['client_id' => '123', 'auth_token' => 'def', 'store_hash' => 'abc', 'client_secret' => 'zyx']);
+        $clientSecret = 'zyx-test-secret-key-that-is-long-enough-for-hs256';
+        Client::configureOAuth(['client_id' => '123', 'auth_token' => 'def', 'store_hash' => 'abc', 'client_secret' => $clientSecret]);
         $expectedPayload = ['iss' => '123', 'operation' => 'customer_login', 'store_hash' => 'abc', 'customer_id' => 1];
         $token = Client::getCustomerLoginToken(1);
-        $key = new \Firebase\JWT\Key('zyx', 'HS256');
+        $key = new \Firebase\JWT\Key($clientSecret, 'HS256');
         $actualPayload = (array)\Firebase\JWT\JWT::decode($token, $key);
         foreach ($expectedPayload as $value) {
             $this->assertContains($value, $actualPayload);


### PR DESCRIPTION
Jira: [PHPMNT-347](https://bigcommercecloud.atlassian.net/browse/PHPMNT-347)

## What/Why?
Extends the `firebase/php-jwt` version constraint from `~5.0 || ~6.0` to also accept `^7.0`.

This is required so systems depending on this library can upgrade to `firebase/php-jwt ^7.0` to fix CVE-2025-45769 (weak encryption, CWE-326). The only usage in this package is `JWT::encode($payload, $secret, 'HS256')`, which is fully compatible with v7

## Rollout/Rollback
Merge / revert

## Testing
CI on this PR

[PHPMNT-347]: https://bigcommercecloud.atlassian.net/browse/PHPMNT-347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ